### PR TITLE
Fix JSON parsing error for empty relations + test

### DIFF
--- a/lib/src/osm_elements/osm_relation.dart
+++ b/lib/src/osm_elements/osm_relation.dart
@@ -28,17 +28,16 @@ class OSMRelation extends OSMElement {
    * A factory method for constructing an [OSMRelation] from a JSON object.
    */
   factory OSMRelation.fromJSONObject(Map<String, dynamic> obj) {
-    var members = <OSMMember>[];
-    for (var memberObj in obj['members']) {
-      var typeEnum = OSMElementType.values.firstWhere((e) => e.name == memberObj['type']);
-      members.add(
-        OSMMember(
-          type: typeEnum,
-          ref: memberObj['ref'],
-          role: memberObj['role'],
-        )
-      );
-    }
+    // Relations unfortunately can have no members (see https://wiki.openstreetmap.org/wiki/Empty_relations)
+    // In this case the "members" property is omitted/missing.
+    // Therefore a check and fallback to an empty Iterable is required.
+    final List<OSMMember> members = (obj['members'] ?? const Iterable.empty())
+      .map<OSMMember>((memberObj) => OSMMember(
+        type: OSMElementType.values.firstWhere((e) => e.name == memberObj['type']),
+        ref: memberObj['ref'],
+        role: memberObj['role'],
+      ))
+      .toList();
 
     return OSMRelation(
       members,
@@ -50,7 +49,7 @@ class OSMRelation extends OSMElement {
 
 
   /**
-   * A factory method for constructing an [OSMRelation] from a XML [String].
+   * A factory method for constructing an [OSMRelation] from an XML [String].
    */
   factory OSMRelation.fromXMLString(String xmlString) {
     final xmlDoc = XmlDocument.parse(xmlString);
@@ -60,7 +59,7 @@ class OSMRelation extends OSMElement {
 
 
   /**
-   * A factory method for constructing an [OSMRelation] from a XML [XmlElement].
+   * A factory method for constructing an [OSMRelation] from an XML [XmlElement].
    */
   factory OSMRelation.fromXMLElement(XmlElement relationElement) {
     final List<OSMMember> members;

--- a/test/osm_element_api_test.dart
+++ b/test/osm_element_api_test.dart
@@ -281,4 +281,19 @@ void main() async {
       expect(e,  isA<OSMGoneException>());
     }
   });
+
+  test('test parsing empty relation', () async {
+    final emptyRel01 = OSMRelation.fromJSONObject({});
+    expect(emptyRel01.members, isEmpty);
+    expect(emptyRel01.tags, isEmpty);
+    expect(emptyRel01.id, isZero);
+    expect(emptyRel01.version, isZero);
+
+    final emptyRel02 = OSMRelation.fromXMLString('<relation></relation>');
+    expect(emptyRel02.members, isEmpty);
+    expect(emptyRel02.tags, isEmpty);
+    expect(emptyRel02.id, isZero);
+    expect(emptyRel02.version, isZero);
+  });
 }
+


### PR DESCRIPTION
See: https://wiki.openstreetmap.org/wiki/Empty_relations

Example: https://www.openstreetmap.org/relation/10542170/history/474